### PR TITLE
Addition of Imperal Gallons for UK users

### DIFF
--- a/flyway/sql/V1.1__Insert_Base_Units.sql
+++ b/flyway/sql/V1.1__Insert_Base_Units.sql
@@ -18,3 +18,4 @@ INSERT INTO `CurrencyUnits` (`id`, `unit`, `unitName`, `symbol`) VALUES (5, "CAD
 
 INSERT INTO `FuelConsumptionUnits` (`id`, `unit`, `unitName`) VALUES (1, "mpg", "Miles per Gallon");
 INSERT INTO `FuelConsumptionUnits` (`id`, `unit`, `unitName`) VALUES (2, "l/100km", "Litres per 100 Kilometers");
+INSERT INTO `FuelConsumptionUnits` (`id`, `unit`, `unitName`) VALUES (3, 'mpg (Imperial)', 'Miles per Gallon');

--- a/flyway/sql/V1.1__Insert_Base_Units.sql
+++ b/flyway/sql/V1.1__Insert_Base_Units.sql
@@ -18,4 +18,3 @@ INSERT INTO `CurrencyUnits` (`id`, `unit`, `unitName`, `symbol`) VALUES (5, "CAD
 
 INSERT INTO `FuelConsumptionUnits` (`id`, `unit`, `unitName`) VALUES (1, "mpg", "Miles per Gallon");
 INSERT INTO `FuelConsumptionUnits` (`id`, `unit`, `unitName`) VALUES (2, "l/100km", "Litres per 100 Kilometers");
-INSERT INTO `FuelConsumptionUnits` (`id`, `unit`, `unitName`) VALUES (3, 'mpg (Imperial)', 'Miles per Gallon');

--- a/src/app/services/conversion/consumption-converter.ts
+++ b/src/app/services/conversion/consumption-converter.ts
@@ -18,12 +18,8 @@ export class ConsumptionConverter {
 
         if ('mpg' === consumptionUnit) {
 
-            const fuelUnitAsGallons = ('gal' === fuelUnit ? fuelUnitConversion.toGallons() : fuelUnitConversion.toGallonsUS());
+            const fuelUnitAsGallons = ('gal (US)' === fuelUnit ? fuelUnitConversion.toGallonsUS() : fuelUnitConversion.toGallons());
             return Math.round((distanceUnitConversion.toMiles() / fuelUnitAsGallons) * 100) / 100;
-        }
-
-        if ('mpg (Imperial)' == consumptionUnit)  {
-            return Math.round((distanceUnitConversion.toMiles() / fuelUnitConversion.toGallons()) * 100) / 100;
         }
 
         if ('l/100km' === consumptionUnit) {

--- a/src/app/services/conversion/consumption-converter.ts
+++ b/src/app/services/conversion/consumption-converter.ts
@@ -22,6 +22,10 @@ export class ConsumptionConverter {
             return Math.round((distanceUnitConversion.toMiles() / fuelUnitAsGallons) * 100) / 100;
         }
 
+        if ('mpg (Imperial)' == consumptionUnit)  {
+            return Math.round((distanceUnitConversion.toMiles() / fuelUnitConversion.toGallons()) * 100) / 100;
+        }
+
         if ('l/100km' === consumptionUnit) {
             return Math.round(((fuelUnitConversion.toLitres() / distanceUnitConversion.toKilometers()) * 100) * 100) / 100;
         }


### PR DESCRIPTION
In the UK, we measure fuel consumption in imperial miles per gallon, but use litres to fill. The existing conditional statement will only allow imperal gallons if the fuelUnit == gal. This may work in most parts of the world, however for us strange brits using litres this results in iffy readings. This is a corrective fix to resolve this.

Has been tested against manual conversions - any feedback appreciated. 